### PR TITLE
Update replace path for libsynophoto-plugin-model.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Synology Photos Facial Recognition Patch
 3. Please change 'jinlife' to your own account.
 4. Restart Photos after patch.
 ```bash
-cp /volume1/homes/jinlife/libsynophoto-plugin-model.so /var/packages/SynologyPhotos/target/usr/lib/ 
+cp /volume1/homes/jinlife/libsynophoto-plugin-model.so /var/packages/SynologyPhotos/target/usr/lib/libsynophoto-plugin-model.so.1.0
 ```
 
 ## Misc (libsynosdk.so.7)


### PR DESCRIPTION
```
# ls -al /var/packages/SynologyPhotos/target/usr/lib | grep plugin-model
lrwxrwxrwx 1 SynologyPhotos SynologyPhotos        30 Nov 11 13:31 libsynophoto-plugin-model.so -> libsynophoto-plugin-model.so.1
lrwxrwxrwx 1 SynologyPhotos SynologyPhotos        32 Nov 11 13:31 libsynophoto-plugin-model.so.1 -> libsynophoto-plugin-model.so.1.0
-rwxr-xr-x 1 SynologyPhotos SynologyPhotos    223075 Nov 11 13:31 libsynophoto-plugin-model.so.1.0
```
As you can see the libsynophoto-plugin-model.so is just a link, the actual target is libsynophoto-plugin-model.so.1.0.